### PR TITLE
🎨 优化日历视图：调整已完成任务的样式，使用降低透明度替代删除线；增强事件标题和时间的布局；添加分类和项目徽章功能

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1233,13 +1233,7 @@
 
 
 
-.fc-event.completed .reminder-calendar-event-content {
-    text-decoration: line-through;
-}
-
-.fc-event.completed .reminder-calendar-event-content .fc-event-title {
-    text-decoration: line-through;
-}
+/* 已完成任务：使用降低透明度替代删除线，复选框已提供足够的完成状态指示 */
 
 .reminder-calendar-event-note {
     font-size: 0.85em;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4575,7 +4575,7 @@ export default class ReminderPlugin extends Plugin {
             // 如果到了同步时间
             if (now >= lastSyncMs + intervalMs) {
                 console.log(`[Timer] Syncing ICS subscription: ${sub.name}`);
-                const result = await syncSubscription(sub);
+                const result = await syncSubscription(this, sub);
 
                 // 更新订阅状态信息
                 sub.lastSync = new Date().toISOString();


### PR DESCRIPTION
完成 [issue 288](https://github.com/Achuan-2/siyuan-plugin-task-note-management/issues/288)

🎨 优化日历视图：

1. 调整已完成任务的样式，使用降低透明度替代删除线；
2. 增强事件标题和时间的布局；
3. 添加分类和项目徽章功能；

效果如下：
<img width="3020" height="2080" alt="image" src="https://github.com/user-attachments/assets/146cc3aa-6f1a-44ef-926c-aba4247f9e2b" />

1. 默认完成元素，0.65 透明度，为方便查看，鼠标悬浮恢复 1
2. 现在在 checkbox 前，插入所属项目图标，如果没有项目图标则使用项目首字（英文转大写首字）
3. 为保持样式的统一性，隐藏备注，讲备注也放在悬浮的时候查看
4. 对于番茄钟的样式和普通 top-row 的样式都做了兼容

其他尚未考虑的影响范围：移动端修改样式，未测试